### PR TITLE
Un-dating reference to ISO 8601

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
       <li><cite id="bib-iso-80000">ISO 80000 (all parts)</cite>, Quantities and units</li>
       <li><cite id="bib-iso-80000-1">ISO 80000-1</cite>, Quantities and units — Part 1: General
         <a>https://www.iso.org/standard/30669.html</a></li>
-      <li><cite id="bib-iso-8601-2014">ISO 8601:2004</cite>, Data elements and interchange formats — Information interchange — Representation of dates and times
+      <li><cite id="bib-iso-8601-2004">ISO 8601</cite>, Data elements and interchange formats — Information interchange — Representation of dates and times (2004)
         <a>https://www.iso.org/standard/40874.html</a></li>
       <li><cite id="bib-iso-iec-10646">ISO/IEC 10646</cite>, Information technology — Universal coded character set (UCS)
         <a>https://www.iso.org/standard/76835.html</a></li>
@@ -336,12 +336,12 @@ This annex lists non-prose elements of this document.
       <p>Dates shall:</p>
       <ul>
         <li>be written as <code>YYYY-MM-DD</code>, e.g. 2009-04-23 to indicate April 23, 2009; or</li>
-        <li>conform to <a href="#bib-iso-8601-2014"></a>, including additional time zone metadata.</li>
+        <li>conform to <a href="#bib-iso-8601-2004"></a>, including additional time zone metadata.</li>
       </ul>
       <p>Times shall:</p>
       <ul>
         <li>be written as one of <code>hh:mm</code>, <code>hh:mm:ss</code>, where <code>hh</code> is the hour (in a 24-hour day), <code>mm</code> are the minutes and <code>ss</code> are the seconds; or </li>
-        <li>conform to <a href="#bib-iso-8601-2014"></a>.</li>
+        <li>conform to <a href="#bib-iso-8601-2004"></a>.</li>
       </ul>
 
       <p>The above only apply to calendar dates and time, and do not apply to timecode and other forms of media time. The latter can, for example, include an <code>ff</code> suffix to denote a frame count.</p>


### PR DESCRIPTION
- Removed date from cited document title
- Fixed date in citation id
- Closes #6 